### PR TITLE
Workaround for dotnet-cli Issue 1582

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM ubuntu:trusty
 
+# Work around https://github.com/dotnet/cli/issues/1582 until Docker releases a
+# fix (https://github.com/docker/docker/issues/20818). This workaround allows
+# the container to be run with the default seccomp Docker settings by avoiding
+# the restart_syscall made by LTTng which causes a failed assertion.
+ENV LTTNG_UST_REGISTER_TIMEOUT 0
+
 # Install dotnet-nightly
 RUN sh -c 'echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list' \
     && apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 \


### PR DESCRIPTION
Got the following error running docknet: "lttng-ust-comm.c:1446: lttng_ust_init: Assertion `!ret' failed."

Implemented the workaround for issue 1582 on dotnet/cli:

``` dockerfile
# Work around https://github.com/dotnet/cli/issues/1582 until Docker releases a
# fix (https://github.com/docker/docker/issues/20818). This workaround allows
# the container to be run with the default seccomp Docker settings by avoiding
# the restart_syscall made by LTTng which causes a failed assertion.
ENV LTTNG_UST_REGISTER_TIMEOUT 0
```

This fixes Issue #1: Issue with docknet docker image/dotnetproxy script
